### PR TITLE
Remove tomato due to its tariff classification

### DIFF
--- a/fruit.txt
+++ b/fruit.txt
@@ -5,4 +5,3 @@ guava
 pear
 pineapple
 strawberry
-tomato


### PR DESCRIPTION
In the United States, under some tariff classifications, tomatoes are
vegetables not fruits.
